### PR TITLE
Fixed: Bug PI or SP

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,6 +143,8 @@ function clearResult() {
   validPutOperator=false;
 }
 
+let previous_key; // This would store the previouw key that was being pressed 
+
 // Add a keydown event listener to the document
 document.addEventListener('keydown', (event) => {
   // Get the pressed key
@@ -153,23 +155,17 @@ document.addEventListener('keydown', (event) => {
     appendOperation('e');
   } else if (key === '^') {
     appendFunction('^');
-  } else if (key === 's') {
+  } else if (previous_key === "s" && key === 'p') { // Changing these functions from using new eventlistener it would instantiate a new event listener what caused the duplication of the PI's and SQRT's  - Jiri132
     // Check if the next key pressed is "p"
-    document.addEventListener('keydown', (nextEvent) => {
-      if (nextEvent.key === 'p') {
-        appendFunction('&#8730;'); // Append "sprt" to the expression
-        nextEvent.preventDefault(); // Prevent the default behavior of the "p" key
-      }
-    });
-  } else if (key === 'p') {
+    appendFunction('&#8730;'); // Append "sprt" to the expression
+    event.preventDefault(); // Prevent the default behavior of the "p" key
+      
+  } else if (previous_key === "p" && key === "i") {
     //  Please note that this solution assumes that the calculator does not have any other functionality associated with the key combination "pi". If there are conflicting key combinations or additional requirements, further modifications may be neccessary
     // Check if the next key pressed is "i"
-    document.addEventListener('keydown', (nextEvent) => {
-      if (nextEvent.key === 'i') {
-        appendOperation('π'); // Append "pi" to the expression
-        nextEvent.preventDefault(); // Prevent the default behavior of the "i" key
-      }
-    });
+    appendOperation('π'); // Append "pi" to the expression
+    event.preventDefault(); // Prevent the default behavior of the "i" key
+      
   } else if (/[0-9.]/.test(key)) {
     appendOperation(key);
   } else if (/[+\-*/]/.test(key)) {
@@ -179,6 +175,8 @@ document.addEventListener('keydown', (event) => {
   } else if (key === 'Enter' || key === '=') {
     calculateResult();
   }
+
+  previous_key = key; // Store the pressed key in the variable
 });
 
 document.addEventListener('keydown', function (event) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to appwrite here: https://github.com/N3v1/Calculator/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## What does this PR do?
This PR fixes the bug of pi and sp it now instantiates more and more them more you want to use the abreviations sp and pi

## Test Plan
tested it on paper and looked at why it went wrong.

It went wrong because the new event listeners got instantiated to only look for I or P the next time and because of PI is 1x extra event it will do once the second time it is PI, it makes a new event listener again, so pressing I would use both eventlisteners then and will be getting 2 pi's when just pressing I.

So the issue was pressing P instantiates new Event listeners that would instantiate PI signs on the amount of event listeners there where.

I wisted it so that the previous key always is being seen and it checks with the previous key if the abbreviation is correct.

## Related PRs and Issues
#60

## Checklist

- [x] Have you read the [Contributing Guidelines on issues](https://github.com/N3v1/Calculator/blob/master/CONTRIBUTING.md)?
